### PR TITLE
Add pure input datasets loader (datasets with no available ground truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The results will be available under `data/out`
 
 ### Training, Test & Inference
 The training, test and inference scripts are made available in the repository root folder and serve as examples on how you can train and monitor your custom training runs.
+The training script produces logfiles in the current working directory for usage with tensorboard, a visualization tool to see what is going on during training, test and inference. To inspect the logfiles (at runtime or post-training), use `tensorboard --logdir your_logfile_path`, the visualizations can then be seen in your browser.
 
 ### Depth Estimation
 The `depth_estimation` module contains python packages with the code for setting up the model as well as utils to load data, compute losses and visualize data during training.

--- a/data/example_dataset/dataset.py
+++ b/data/example_dataset/dataset.py
@@ -5,6 +5,7 @@ import csv
 
 from depth_estimation.utils.data import (
     InputTargetDataset,
+    InputDataset,
     IntPILToTensor,
     FloatPILToTensor,
     MutualRandomFactor,
@@ -67,5 +68,25 @@ def get_example_dataset(train=False, shuffle=False, device="cpu"):
         max_priors=200,
         shuffle=shuffle,
     )
+
+    return dataset
+
+def get_example_dataset_inference(priors=True):
+
+    # filenames
+    index_file = "data/example_dataset/dataset.csv"
+    lines = csv.reader(open(index_file).read().splitlines())
+    rgb_target_priors_tuples = [i for i in lines]
+
+    # image transform
+    image_transform = IntPILToTensor(type="uint8")
+
+    # priors (or not)
+    if priors:
+        tuples = [[t[0], t[2]] for t in rgb_target_priors_tuples]  # omit target depth maps
+        dataset = InputDataset(tuples, image_transform, max_priors=200)
+    else:
+        tuples = [[t[0]] for t in rgb_target_priors_tuples]  # omit target depth maps and priors
+        dataset = InputDataset(tuples, image_transform, max_priors=0)  
 
     return dataset

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -11,3 +11,6 @@ opencv-contrib-python
 torch
 torchvision
 torchaudio
+
+# visualization
+tensorboard

--- a/depth_estimation/utils/data.py
+++ b/depth_estimation/utils/data.py
@@ -49,7 +49,7 @@ class InputTargetDataset:
         self.max_priors = max_priors
 
         # checking dataset for missing files
-        if not self.check_dataset():
+        if not check_dataset(self.path_tuples):
             print("WARNING, dataset has missing files!")
             # exit(1)
 

--- a/depth_estimation/utils/data.py
+++ b/depth_estimation/utils/data.py
@@ -82,7 +82,7 @@ class InputTargetDataset:
             return self[random_idx]  # recursion
 
         # read sparse depth priors
-        depth_samples = self.read_features(depth_samples_fn, device=target_img.device)
+        depth_samples = read_features(depth_samples_fn, self.max_priors, device=target_img.device)
 
         # check if features has at least one entry
         if depth_samples is None:
@@ -113,19 +113,19 @@ class InputTargetDataset:
 
         return tensor_list
 
-    def check_dataset(self):
+def check_dataset(path_tuples):
         """Checks dataset for missing files."""
-        for tuple in self.path_tuples:
+        for tuple in path_tuples:
             for f in tuple:
                 if not exists(f):
                     print(f"Missing file: {f}.")
                     return False
 
-        print(f"Checked {len(self.path_tuples)} tuples for existence, all ok.")
+        print(f"Checked {len(path_tuples)} tuples for existence, all ok.")
 
         return True
 
-    def read_features(self, path, device="cpu"):
+def read_features(path, max_priors, device="cpu"):
         """Read sparse priors from file and store in torch tensor."""
 
         # load samples (might be less than n_samples)
@@ -137,7 +137,7 @@ class InputTargetDataset:
             return None
         else:
             rand_idcs = np.random.permutation(len(depth_samples_data))[
-                : self.max_priors
+                : max_priors
             ]
             depth_samples = depth_samples_data[rand_idcs]  # select subset
 
@@ -145,26 +145,57 @@ class InputTargetDataset:
         depth_samples = torch.from_numpy(depth_samples).to(device)
 
         return depth_samples
-    
+
+
 class InputDataset:
-    """Similar to InputTargetDataset above, but for inference only"""
+    """Similar to InputTargetDataset above, but for inference only. If priors are not available, set `max_priors` to zero."""
 
-    def __init__(self, img_files):#, device="cpu") -> None:
-        self.img_files = img_files
-        # self.device = device
+    def __init__(self, rgb_priors_tuples, image_transform, max_priors=200) -> None:
+        
+        self.path_tuples = rgb_priors_tuples
+        self.image_transform = image_transform
+        self.max_priors = max_priors
 
+        if self.max_priors > 0:
+            print(f"Using priors (max {self.max_priors} per image).")
+            check_dataset(self.path_tuples)
+        else: 
+            image_fns = [[t[0]] for t in self.path_tuples]
+            print("Not using priors, using nullprior as placeholder.")
+            check_dataset(image_fns)
 
     def __len__(self):
-        return len(self.img_files)
+        return len(self.path_tuples)
     
     def __getitem__(self, idx):
 
-        img = Image.open(self.img_files[idx]).resize((640, 480))
+        # get img filename
+        input_fn = self.path_tuples[idx][0]
 
-        tf = IntPILToTensor()
-        img = tf(img)
+        # read img
+        input_img = Image.open(input_fn).resize((640, 480))
 
-        return [img]
+        # apply image transforms to get tensor
+        input_img = self.image_transform(input_img)
+
+        if self.max_priors > 0:
+
+            # get keypoints filename
+            depth_samples_fn = self.path_tuples[idx][1]
+
+            # read sparse depth priors
+            depth_samples = read_features(depth_samples_fn, self.max_priors, device=input_img.device)
+            
+            # get dense parametrization from sparse priors
+            parametrization = get_depth_prior_from_features(
+                features=depth_samples.unsqueeze(0),  # add batch dimension
+                height=240,
+                width=320,
+            ).squeeze(0)
+
+            return [input_img, parametrization]
+        else:
+            return [input_img]
 
 
 class MutualRandomHorizontalFlip:

--- a/inference.py
+++ b/inference.py
@@ -11,7 +11,7 @@ from depth_estimation.model.model import UDFNet
 from depth_estimation.utils.visualization import gray_to_heatmap
 
 # from datasets.datasets import get_flsea_dataset
-from data.example_dataset.dataset import get_example_dataset
+from data.example_dataset.dataset import get_example_dataset, get_example_dataset_inference
 
 
 BATCH_SIZE = 6
@@ -19,7 +19,11 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 MODEL_PATH = (
     "data/saved_models/model_e11_udfnet_lr0.0001_bs6_lrd0.9_with_infguidance.pth"
 )
-DATASET = get_example_dataset(train=False, shuffle=False, device=DEVICE)
+DATASET = get_example_dataset_inference(priors=True)
+# MODEL_PATH = (
+#     "data/saved_models/model_e24_udfnet_lr0.0001_bs6_lrd0.9_nullpriors.pth"
+# )
+# DATASET = get_example_dataset_inference(priors=False)
 OUT_PATH = "data/out"
 SAVE = True
 
@@ -46,11 +50,12 @@ def inference():
 
         # inputs
         rgb = data[0].to(DEVICE)  # RGB image
-        prior = data[3].to(DEVICE)  # precomputed features and depth values
-        # prior = torch.zeros(BATCH_SIZE,2,240,320).to(DEVICE)  # use this as placeholder if you dont have priors
 
-        # nullprior, use this if you are using a model that was trained with nullpriors
-        # prior[:, :, :, :] = 0.0
+        # using priors from files or not
+        if len(data) > 1:
+            prior = data[1].to(DEVICE)  # precomputed features and depth values
+        else: 
+            prior = torch.zeros(BATCH_SIZE,2,240,320).to(DEVICE)  # if you dont have/want priors
 
         # outputs
         start_time = time.time()

--- a/inference.py
+++ b/inference.py
@@ -10,9 +10,12 @@ from torchvision.transforms import Resize
 from depth_estimation.model.model import UDFNet
 from depth_estimation.utils.visualization import gray_to_heatmap
 
-# from datasets.datasets import get_flsea_dataset
 from data.example_dataset.dataset import get_example_dataset, get_example_dataset_inference
 
+
+############################################################
+###################### CONFIG ##############################
+############################################################
 
 BATCH_SIZE = 6
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -20,12 +23,18 @@ MODEL_PATH = (
     "data/saved_models/model_e11_udfnet_lr0.0001_bs6_lrd0.9_with_infguidance.pth"
 )
 DATASET = get_example_dataset_inference(priors=True)
+OUT_PATH = "data/out"
+SAVE = True
+
+# use this if priors are not available
 # MODEL_PATH = (
 #     "data/saved_models/model_e24_udfnet_lr0.0001_bs6_lrd0.9_nullpriors.pth"
 # )
 # DATASET = get_example_dataset_inference(priors=False)
-OUT_PATH = "data/out"
-SAVE = True
+
+############################################################
+############################################################
+############################################################
 
 
 @torch.no_grad()

--- a/train.py
+++ b/train.py
@@ -16,7 +16,8 @@ from depth_estimation.utils.loss import (
 )
 from depth_estimation.utils.visualization import get_tensorboard_grids
 
-from data.flsea.dataset import get_flsea_dataset
+# from data.flsea.dataset import get_flsea_dataset
+from data.example_dataset.dataset import get_example_dataset
 
 
 ##############################################################
@@ -58,18 +59,21 @@ VALIDATION_LOSS_NAMES = [
 ]
 
 # datasets
-TRAIN_DATASET = get_flsea_dataset(
-    split="dataset_with_matched_features",
-    train=True,
-    shuffle=True,
-    device=DEVICE,
-)
-VALIDATION_DATASET = get_flsea_dataset(
-    split="test_with_matched_features",
-    train=False,
-    shuffle=True,
-    device=DEVICE,
-)
+# TRAIN_DATASET = get_flsea_dataset(
+#     split="dataset_with_matched_features",
+#     train=True,
+#     shuffle=True,
+#     device=DEVICE,
+# )
+# VALIDATION_DATASET = get_flsea_dataset(
+#     split="test_with_matched_features",
+#     train=False,
+#     shuffle=True,
+#     device=DEVICE,
+# )
+
+TRAIN_DATASET = get_example_dataset(train=True, shuffle=True, device=DEVICE)
+VALIDATION_DATASET = get_example_dataset(train=False, shuffle=True, device=DEVICE)  # you should change this, this should not be the same as training
 
 # tensorboard output frequencies
 WRITE_TRAIN_IMG_EVERY_N_BATCHES = 500


### PR DESCRIPTION
For other people to try out this work with their own data, they might not have ground truth data available. 
In this case, a simple `InputDataset` loader is provided s.t. the user can use their own data in a more straightforward matter.